### PR TITLE
Fixed #10, 自定义物品反序列化工具

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
         </repository>
 
         <repository>
+            <id>sonatype-repo</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+
+        <repository>
             <id>github</id>
             <name>GitHub Packages</name>
             <url>https://maven.pkg.github.com/CarmJos/${project.name}</url>

--- a/src/main/java/cc/carm/plugin/userprefix/Main.java
+++ b/src/main/java/cc/carm/plugin/userprefix/Main.java
@@ -14,6 +14,7 @@ import cc.carm.plugin.userprefix.manager.ServiceManager;
 import cc.carm.plugin.userprefix.manager.UserManager;
 import cc.carm.plugin.userprefix.util.ColorParser;
 import cc.carm.plugin.userprefix.util.MessageUtil;
+import cc.carm.plugin.userprefix.wrapper.ItemStackWrapper;
 import net.luckperms.api.event.user.UserDataRecalculateEvent;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
@@ -22,6 +23,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.command.TabCompleter;
+import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -38,6 +40,9 @@ public class Main extends JavaPlugin {
         showPluginName();
         log(getName() + " " + getDescription().getVersion() + " &7开始加载...");
         long startTime = System.currentTimeMillis();
+
+        log("注入序列化处理工具...");
+        ConfigurationSerialization.registerClass(ItemStackWrapper.class);
 
         log("加载配置文件...");
         ConfigManager.initConfig();

--- a/src/main/java/cc/carm/plugin/userprefix/configuration/file/FileConfig.java
+++ b/src/main/java/cc/carm/plugin/userprefix/configuration/file/FileConfig.java
@@ -1,8 +1,8 @@
 package cc.carm.plugin.userprefix.configuration.file;
 
 
+import cc.carm.plugin.userprefix.util.ConfigurationUtil;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
@@ -35,7 +35,7 @@ public class FileConfig {
             }
             plugin.saveResource(fileName, true);
         }
-        this.config = YamlConfiguration.loadConfiguration(this.file);
+        this.config = ConfigurationUtil.bang(this.file);
     }
 
     public File getFile() {
@@ -56,7 +56,7 @@ public class FileConfig {
 
     public void reload() {
         if (getFile().exists()) {
-            this.config = YamlConfiguration.loadConfiguration(getFile());
+            this.config =  ConfigurationUtil.bang(getFile());
         } else {
             initFile();
         }

--- a/src/main/java/cc/carm/plugin/userprefix/model/ConfiguredPrefix.java
+++ b/src/main/java/cc/carm/plugin/userprefix/model/ConfiguredPrefix.java
@@ -1,11 +1,11 @@
 package cc.carm.plugin.userprefix.model;
 
 import cc.carm.plugin.userprefix.util.ColorParser;
+import cc.carm.plugin.userprefix.util.ConfigurationUtil;
 import cc.carm.plugin.userprefix.util.ItemStackFactory;
 import cc.carm.plugin.userprefix.util.MessageUtil;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -38,7 +38,11 @@ public class ConfiguredPrefix {
 
 	public ConfiguredPrefix(@NotNull File dataFile) {
 		this.dataFile = dataFile;
-		this.configuration = YamlConfiguration.loadConfiguration(dataFile);
+		try {
+			this.configuration = ConfigurationUtil.bang(dataFile);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
 		if (getConfiguration() != null) {
 			this.identifier = getConfiguration().getString("identifier", "ERROR");
 			this.name = getConfiguration().getString("name", "ERROR");

--- a/src/main/java/cc/carm/plugin/userprefix/util/ConfigurationUtil.java
+++ b/src/main/java/cc/carm/plugin/userprefix/util/ConfigurationUtil.java
@@ -1,0 +1,38 @@
+package cc.carm.plugin.userprefix.util;
+
+import cc.carm.plugin.userprefix.wrapper.ItemStackWrapper;
+import com.google.common.io.Files;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.inventory.ItemStack;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.StringJoiner;
+
+public class ConfigurationUtil {
+    public static FileConfiguration bang(File file) {
+        YamlConfiguration conf = new YamlConfiguration();
+        StringJoiner builder = new StringJoiner("\n");
+        try {
+            //noinspection UnstableApiUsage
+            Files.readLines(file, StandardCharsets.UTF_8).forEach(builder::add);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return conf;
+        }
+        String tmpConf = builder.toString().replace("==: "+ ItemStack.class.getName(), "==: "+ ItemStackWrapper.class.getName());
+        try {
+             conf.loadFromString(tmpConf);
+        } catch (InvalidConfigurationException e) {
+            e.printStackTrace();
+        }
+        return conf;
+    }
+
+    public static String dong(YamlConfiguration conf) {
+        return conf.saveToString().replace("==: "+ ItemStackWrapper.class.getName(),"==: "+ ItemStack.class.getName());
+    }
+}

--- a/src/main/java/cc/carm/plugin/userprefix/util/ConfigurationUtil.java
+++ b/src/main/java/cc/carm/plugin/userprefix/util/ConfigurationUtil.java
@@ -32,7 +32,7 @@ public class ConfigurationUtil {
         return conf;
     }
 
-    public static String dong(YamlConfiguration conf) {
+    public static String dong(FileConfiguration conf) {
         return conf.saveToString().replace("==: "+ ItemStackWrapper.class.getName(),"==: "+ ItemStack.class.getName());
     }
 }

--- a/src/main/java/cc/carm/plugin/userprefix/wrapper/ItemStackWrapper.java
+++ b/src/main/java/cc/carm/plugin/userprefix/wrapper/ItemStackWrapper.java
@@ -1,6 +1,5 @@
 package cc.carm.plugin.userprefix.wrapper;
 
-import cc.carm.plugin.userprefix.Main;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
@@ -36,11 +35,9 @@ public class ItemStackWrapper implements ConfigurationSerializable {
                 if (material == null) {
                     throw new IllegalArgumentException("物品 "+args.get("type")+" 不存在");
                 }
-                Main.getInstance().getLogger().info("Patched ItemStack with number" + Bukkit.getServer().getUnsafe().getDataVersion() + "!");
                 args.put("v", Bukkit.getServer().getUnsafe().getDataVersion());
             }
         }
-        args.forEach((key, value) -> Main.log(key + ": " + value));
         return ItemStack.deserialize(args);
     }
 }

--- a/src/main/java/cc/carm/plugin/userprefix/wrapper/ItemStackWrapper.java
+++ b/src/main/java/cc/carm/plugin/userprefix/wrapper/ItemStackWrapper.java
@@ -1,0 +1,46 @@
+package cc.carm.plugin.userprefix.wrapper;
+
+import cc.carm.plugin.userprefix.Main;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+public class ItemStackWrapper implements ConfigurationSerializable {
+    private static boolean unsafeAvailable;
+
+    static {
+        try {
+            Class.forName("org.bukkit.UnsafeValues");
+            unsafeAvailable = true;
+        } catch (ClassNotFoundException e) {
+            unsafeAvailable = false;
+        }
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> serialize() {
+        throw new UnsupportedOperationException("Use ConfigurationUtil#dong to save configuration");
+    }
+
+    @NotNull
+    public static ItemStack deserialize(@NotNull Map<String, Object> args) {
+        // static define will cause problem, lazy load it
+        if (unsafeAvailable) {
+            if (!args.containsKey("v")) {
+                Material material = Material.matchMaterial(args.get("type").toString());
+                if (material == null) {
+                    throw new IllegalArgumentException("物品 "+args.get("type")+" 不存在");
+                }
+                Main.getInstance().getLogger().info("Patched ItemStack with number" + Bukkit.getServer().getUnsafe().getDataVersion() + "!");
+                args.put("v", Bukkit.getServer().getUnsafe().getDataVersion());
+            }
+        }
+        args.forEach((key, value) -> Main.log(key + ": " + value));
+        return ItemStack.deserialize(args);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,7 +7,6 @@ authors:
   - SakuraGame
 website: ${project.url}
 description: ${project.description}
-
 api-version: 1.13
 
 depend:


### PR DESCRIPTION
艺术就是爆炸！
<img src="https://user-images.githubusercontent.com/30802565/154840630-bff83cae-0c24-47b2-a78e-6f8658c420dd.jpg" width="30%" height="30%" />
该 PR 劫持配置文件读取并将 ItemStack 序列化器替换为 UserPrefix 的后，通过在 1.13+ 和更高版本服务器上对 ItemStack 的 Map 进行修补，以避免 [Bukkit 添加 `Material.LEGACY_PREFIX`](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/browse/src/main/java/org/bukkit/inventory/ItemStack.java#491) 导致 Material 获取失败。  

请注意，读取配置文件时请使用 `FileConfiguration conf = ConfigurationUtil.bang(File)` 爆米花一下配置文件才能成功劫持。  
写入配置文件时请使用 `String str = ConfigurationUtil.dong(FileConfiguration)`，否则双爆的爆米花容易糊。  

