### PR TITLE
[ci skip] 修复 "Bug 反馈" Issue 模板无法使用

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugs_report.md
+++ b/.github/ISSUE_TEMPLATE/bugs_report.md
@@ -1,6 +1,9 @@
 ---
-name: 问题提交 about: 描述问题并提交，帮助我们对其进行检查与修复。 title: ''
-labels: bug assignees: ''
+name: 问题提交 
+about: 描述问题并提交，帮助我们对其进行检查与修复。 
+title: ''
+labels: bug 
+assignees: ''
 
 ---
 


### PR DESCRIPTION
如题，想要反馈新 Bug 时发现 "Bug 反馈" 的 Issue 模板无法使用，便简单进行了调试修复。

添加了 [ci skip] 以避免无意义的构建参与。