### PR TITLE
Fix Folia detection

### DIFF
--- a/src/main/java/cc/carm/plugin/userprefix/Main.java
+++ b/src/main/java/cc/carm/plugin/userprefix/Main.java
@@ -41,7 +41,7 @@ public class Main extends EasyPlugin {
         instance = this;
 
         try {
-            Class.forName("io.papermc.paper.threadedregions.RegionizedServerInitEvent");
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
             this.onFolia = true;
         } catch (ClassNotFoundException e) {
             this.onFolia = false;


### PR DESCRIPTION
Paper have included `io.papermc.paper.threadedregions.RegionizedServerInitEvent` in 1.21.8, should use `io.papermc.paper.threadedregions.RegionizedServer` for proper Folia detection.

Closes #122.